### PR TITLE
Add a missing float32 case.

### DIFF
--- a/ast2.go
+++ b/ast2.go
@@ -778,6 +778,8 @@ func (n *Expression) eval(lx *lexer) (interface{}, Type) {
 			n.Value = -x
 		case int64:
 			n.Value = -x
+		case float32:
+			n.Value = -x
 		case float64:
 			n.Value = -x
 		default:


### PR DESCRIPTION
Add a missing float32 case.

```
panic: internal error: float32

goroutine 1 [running]:
panic(0x2ea820, 0xc420db86c0)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/cznic/cc.(*Expression).eval(0xc4209c5080, 0xc420374960, 0x2d7ea0, 0xc420db8698, 0x4f45e0, 0xc420365ce0)
github.com/cznic/cc/ast2.go:784 +0x2506
github.com/cznic/cc.yyParse(0x4e9300, 0xc420374960, 0x68ffa)
github.com/cznic/cc/parser.go:2723 +0x27be
```