### PR TITLE
Fix "panic: internal error uint32"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@
 Dan Kortschak <dan.kortschak@adelaide.edu.au>
 Jan Mercl <0xjnml@gmail.com>
 Maxim Kupriianov <max@kc.vc>
+Peter Waller <p@pwaller.net>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,3 +9,4 @@
 Dan Kortschak <dan.kortschak@adelaide.edu.au>
 Jan Mercl <0xjnml@gmail.com>
 Maxim Kupriianov <max@kc.vc>
+Peter Waller <p@pwaller.net>

--- a/model.go
+++ b/model.go
@@ -356,6 +356,13 @@ func (m *Model) MustConvert(v interface{}, typ Type) interface{} {
 			default:
 				panic(w)
 			}
+		case uint32:
+			switch w {
+			case 2:
+				return uint16(x)
+			default:
+				panic(w)
+			}
 		default:
 			panic(fmt.Errorf("internal error %T", x))
 		}


### PR DESCRIPTION
I encountered this while using xlab/cgogen. I'm not sure if this fix
is valid, but it does avoid the panic.